### PR TITLE
Fix encoding issue

### DIFF
--- a/json-crawler.py
+++ b/json-crawler.py
@@ -272,7 +272,7 @@ if __name__ == "__main__":
     #         json.dump(line, raw_log, indent=4)
 
     log_file = "output_log.txt"
-    with open(log_file, "w") as log:
+    with open(log_file, "w", , encoding="utf-8") as log:
         log.write("List of files we skipped (Already existed):\n")
         # while not skipped_files.empty():
         #     item = skipped_files.get().strip()

--- a/json-crawler.py
+++ b/json-crawler.py
@@ -272,7 +272,7 @@ if __name__ == "__main__":
     #         json.dump(line, raw_log, indent=4)
 
     log_file = "output_log.txt"
-    with open(log_file, "w", , encoding="utf-8") as log:
+    with open(log_file, "w", encoding="utf-8") as log:
         log.write("List of files we skipped (Already existed):\n")
         # while not skipped_files.empty():
         #     item = skipped_files.get().strip()


### PR DESCRIPTION
When writing log file if no character encoding is found you get

UnicodeEncodeError: 'charmap' codec can't encode character '\u0430' in position 61: character maps to <undefined>

This PR ensures it uses UTF-8 for log file